### PR TITLE
fix: explicitly include fancyqr from submodule

### DIFF
--- a/slides/template/lecture.tex
+++ b/slides/template/lecture.tex
@@ -54,7 +54,7 @@
 \usepackage{catchfile} % read picture sources from files
 \usepackage{silence} % ignore some warnings
 \WarningFilter{latex}{You have requested package} % ignore warning for loading packages from submodules
-\usepackage{fancyqr} % QR codes for practice task, credits to Florian Sihler
+\usepackage{../EagleoutIce-fancyqr/fancyqr} % QR codes for practice task, credits to Florian Sihler
 \fancyqrset{gradient=true,gradient angle=-45,l color=black,r color=blue}
 \usepackage{ifthen} % \ifuniversity
 \usepackage{booktabs} % tables


### PR DESCRIPTION
On my system, I have fancyqr installed locally, too. Compilation used the locally installed version, not the submodule. This was a problem because my locally installed version was outdated and produced buggy QR codes.

I hope this does not introduce any bugs.