### PR TITLE
Some forgotten changes from last summer

### DIFF
--- a/slides/compile_paderborn.sh
+++ b/slides/compile_paderborn.sh
@@ -16,7 +16,7 @@ lecture_names=("introduction" "runtime" "cloneandown" "modeling" "conditional" "
 university=paderborn
 semester=2024s
 
-archive_path="../../SPL-Slide-Archive/"
+archive_path="../../Course-on-Software-Product-Lines-Slide-Archive/"
 slide_path="../../SPL-Slides/${semester}t/"
 
 make_lecture () {

--- a/slides/content/01c-course-paderborn.tex
+++ b/slides/content/01c-course-paderborn.tex
@@ -103,7 +103,8 @@
 				\item FAQ at the end of each lecture
 			\end{itemize}
 		\end{definition}
-		\begin{definition}{Exam Eligibility \deutsch{Prüfungszulassung}} % TODO check
+		% \begin{definition}{Exam Eligibility \deutsch{Prüfungszulassung}} % TODO check
+		\begin{definition}{Course Achievement \deutsch{Studienleistung}}
 			\begin{itemize}
 				\item pass all 6 practical tasks $\rightarrow$ eligible for exam
 				\item develop your own software product line

--- a/slides/content/literature.tex
+++ b/slides/content/literature.tex
@@ -37,7 +37,7 @@
 \newcommand{\samplingsurvey}{\href{https://raw.githubusercontent.com/SoftVarE-Group/Papers/main/2018/2018-SPLC-Varshosaz.pdf}{Varshosaz~et~al.~2018}}
 \newcommand{\samplingsurveydatabase}{\href{https://thomas.xn--thm-ioa.de/sampling/}{Sampling~Database}}
 \newcommand{\seeconomics}{\href{https://rds-ulm.ibs-bw.de/link?kid=027381854}{SE Economics}}
-\newcommand{\seiwhitepaperspl}{\href{https://resources.sei.cmu.edu/asset_files/WhitePaper/2012_019_001_495381.pdf}{Northrop~et~al.~2012}}
+\newcommand{\seiwhitepaperspl}{\href{https://resources.sei.cmu.edu/asset_files/WhitePaper/2012_019_001_495381.pdf}{Northrop~et~al.~2012}} %%% There are only two authors but we still chose et al. here because there are more authors mentioned on the paper with an additional "with" clause.
 \newcommand{\shereverseengineering}{\href{https://dl.acm.org/doi/abs/10.1145/1985793.1985856}{She~et~al.~2011}}
 \newcommand{\softwareclonedetection}{\href{https://www.sciencedirect.com/science/article/abs/pii/S0950584913000323}{Rattan~et~al.~2013}}
 \newcommand{\sommervillelink}[1]{\href{https://ulm.ibs-bw.de/aDISWeb/app?service=direct/0/Home/$DirectLink\&sp=SOPAC00\&sp=SAKSWB-IdNr1615420983}{#1}}


### PR DESCRIPTION
The change in 99c98e272f6f13635680421f50dcfb7670d037ce is up to discussion. To me it seemed sensible to name the archive directory in a way similar to how all the other related repositories are called. All of them are called `Course-on-Software-Product-Lines*`.