### PR TITLE
fix: ambiguity in feature model semantics

### DIFF
--- a/slides/content/04b-transformations.tex
+++ b/slides/content/04b-transformations.tex
@@ -328,9 +328,9 @@ constraints
 			\begin{align*}
 				\uncover<3->{\featureDiagramFn{\Phi}{6ex}{Root,concrete}{Root}}\\
 				\uncover<4->{\featureDiagramFn{\Phi}{6ex}{P,concrete[C,optional,concrete]}{C \pimplies P}}\\
-				\uncover<5->{\featureDiagramFn{\Phi}{6ex}{P,concrete[C,mandatory,concrete]}{C \pequals P}}\\
-				\uncover<6->{\featureDiagramFn{\Phi}{15ex}{P,concrete[$C_1$,or,concrete][\ldots,concrete][$C_n$,concrete]}{\bigvee_{1 \leq i \leq n} C_i \pequals P}}\\
-				\uncover<7->{\featureDiagramFn{\Phi}{15ex}{P,concrete[$C_1$,alternative,concrete][\ldots,concrete][$C_n$,concrete]}{\bigvee_{1 \leq i \leq n} C_i \pequals P}}\\
+				\uncover<5->{\featureDiagramFn{\Phi}{6ex}{P,concrete[C,mandatory,concrete]}{P \pequals C}}\\
+				\uncover<6->{\featureDiagramFn{\Phi}{15ex}{P,concrete[$C_1$,or,concrete][\ldots,concrete][$C_n$,concrete]}{P \pequals \bigvee_{1 \leq i \leq n} C_i}}\\
+				\uncover<7->{\featureDiagramFn{\Phi}{15ex}{P,concrete[$C_1$,alternative,concrete][\ldots,concrete][$C_n$,concrete]}{P \pequals \bigvee_{1 \leq i \leq n} C_i}}\\
 				\uncover<7->{& \pand \bigwedge_{1 \leq i < j \leq n} \pnot (C_i \pand C_j)}
 			\end{align*}
 		\end{definition}


### PR DESCRIPTION
The translation of feature models to propositional formulas was slightly ambiguous. Within the translation of or-groups, the formula
$\bigvee_{1 \leq i \leq n} C_i \Leftrightarrow P$
could be read as
$\bigvee_{1 \leq i \leq n} (C_i \Leftrightarrow P)$
or
$(\bigvee_{1 \leq i \leq n} C_i) \Leftrightarrow P$
where only the first one is correct as defined by the binding precedences. Still it was confusing. This commit also adapts another rule for consistency.

Before:
![Screenshot From 2025-02-18 13-14-40](https://github.com/user-attachments/assets/13db2c35-2c7f-4390-bf1f-538d93cbc3c0)

After:
![Screenshot From 2025-02-18 13-16-31](https://github.com/user-attachments/assets/e8312936-e600-4536-a4ad-7edfed10e7a8)
